### PR TITLE
Upgrade to GPT-5.4 models and add model validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ OPENAI_API_KEY=sk-xxxxxxxxxxxxx
 ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxx
 GEMINI_API_KEY=AIzaxxxxxxxxxxxxx
 
-# デフォルトモデル（省略時: gpt-4.1-nano）
+# デフォルトモデル（省略時: gpt-5.4-nano）
 # VITE_DEFAULT_MODEL=gemini-2.5-flash
 
 # パスワード認証（設定時のみ有効、パスワードのみでログイン）

--- a/api/_shared.js
+++ b/api/_shared.js
@@ -33,6 +33,9 @@ export function resolveKey(provider, clientKeys) {
 async function callOpenAI(model, messages, apiKey, maxTokens) {
   if (!apiKey) throw new Error('OPENAI_API_KEY is not set');
 
+  // GPT-5.4 nano はトークン上限 4000（コスト抑制）、それ以外は 16000
+  const defaultMax = model.includes('nano') ? 4000 : 16000;
+
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -41,7 +44,7 @@ async function callOpenAI(model, messages, apiKey, maxTokens) {
     },
     body: JSON.stringify({
       model,
-      max_completion_tokens: maxTokens || 16000,
+      max_completion_tokens: maxTokens || defaultMax,
       messages,
     }),
   });

--- a/src/components/TextEditor.jsx
+++ b/src/components/TextEditor.jsx
@@ -366,7 +366,16 @@ export default function TextEditor() {
   const [openDropdown, setOpenDropdown] = useState(null);
   const [copied, setCopied] = useState(false);
   const [selectedModel, setSelectedModel] = useState(() => {
-    try { return localStorage.getItem('wa-model') || DEFAULT_MODEL_ID; } catch { return DEFAULT_MODEL_ID; }
+    try {
+      const saved = localStorage.getItem('wa-model');
+      if (!saved) return DEFAULT_MODEL_ID;
+      // 旧モデル ID が残存していたらデフォルトにリセット
+      if (saved !== 'auto' && !AVAILABLE_MODELS.some((m) => m.id === saved)) {
+        localStorage.setItem('wa-model', DEFAULT_MODEL_ID);
+        return DEFAULT_MODEL_ID;
+      }
+      return saved;
+    } catch { return DEFAULT_MODEL_ID; }
   });
   const [availableProviders, setAvailableProviders] = useState({});
   // Client-side API keys (stored in localStorage, sent with requests as fallback)

--- a/src/config/models.js
+++ b/src/config/models.js
@@ -9,8 +9,8 @@ export const PROVIDERS = {
 // secsPerKChar: 1000文字あたりの推定処理秒数（プログレス表示用）
 export const AVAILABLE_MODELS = [
   // OpenAI
-  { id: 'gpt-5.4-nano', provider: 'openai', name: 'GPT-5.4 Nano', description: '最速・最安', inputPrice: 0.10, outputPrice: 0.40, speed: 5, quality: 3, secsPerKChar: 3 },
-  { id: 'gpt-5.4-mini', provider: 'openai', name: 'GPT-5.4 Mini', description: '高品質', inputPrice: 0.40, outputPrice: 1.60, speed: 4, quality: 4, secsPerKChar: 5 },
+  { id: 'gpt-5.4-nano', provider: 'openai', name: 'GPT-5.4 Nano', description: '最速・最安', inputPrice: 0.05, outputPrice: 0.20, speed: 5, quality: 3, secsPerKChar: 3 },
+  { id: 'gpt-5.4-mini', provider: 'openai', name: 'GPT-5.4 Mini', description: '高品質', inputPrice: 0.30, outputPrice: 1.20, speed: 4, quality: 4, secsPerKChar: 5 },
 
   // Anthropic
   { id: 'claude-haiku-4-5-20251001', provider: 'anthropic', name: 'Claude 4.5 Haiku', description: '最速・最安', inputPrice: 0.80, outputPrice: 4.00, speed: 5, quality: 3, secsPerKChar: 4 },
@@ -42,7 +42,7 @@ export function autoSelectModel(charCount, isAvailable) {
   return sorted[0]?.id || DEFAULT_MODEL_ID;
 }
 
-// .envで VITE_DEFAULT_MODEL を指定可能（例: VITE_DEFAULT_MODEL=gpt-4.1-nano）
+// .envで VITE_DEFAULT_MODEL を指定可能（例: VITE_DEFAULT_MODEL=gpt-5.4-nano）
 const envDefault = typeof import.meta !== 'undefined' && import.meta.env?.VITE_DEFAULT_MODEL;
 export const DEFAULT_MODEL_ID = (envDefault && AVAILABLE_MODELS.some((m) => m.id === envDefault)) ? envDefault : 'gpt-5.4-nano';
 

--- a/src/config/models.js
+++ b/src/config/models.js
@@ -9,8 +9,8 @@ export const PROVIDERS = {
 // secsPerKChar: 1000文字あたりの推定処理秒数（プログレス表示用）
 export const AVAILABLE_MODELS = [
   // OpenAI
-  { id: 'gpt-4.1-nano', provider: 'openai', name: 'GPT-4.1 Nano', description: '最速・最安', inputPrice: 0.10, outputPrice: 0.40, speed: 5, quality: 2, secsPerKChar: 3 },
-  { id: 'gpt-4.1-mini', provider: 'openai', name: 'GPT-4.1 Mini', description: 'バランス型', inputPrice: 0.40, outputPrice: 1.60, speed: 4, quality: 3, secsPerKChar: 5 },
+  { id: 'gpt-5.4-nano', provider: 'openai', name: 'GPT-5.4 Nano', description: '最速・最安', inputPrice: 0.10, outputPrice: 0.40, speed: 5, quality: 3, secsPerKChar: 3 },
+  { id: 'gpt-5.4-mini', provider: 'openai', name: 'GPT-5.4 Mini', description: '高品質', inputPrice: 0.40, outputPrice: 1.60, speed: 4, quality: 4, secsPerKChar: 5 },
 
   // Anthropic
   { id: 'claude-haiku-4-5-20251001', provider: 'anthropic', name: 'Claude 4.5 Haiku', description: '最速・最安', inputPrice: 0.80, outputPrice: 4.00, speed: 5, quality: 3, secsPerKChar: 4 },
@@ -44,7 +44,7 @@ export function autoSelectModel(charCount, isAvailable) {
 
 // .envで VITE_DEFAULT_MODEL を指定可能（例: VITE_DEFAULT_MODEL=gpt-4.1-nano）
 const envDefault = typeof import.meta !== 'undefined' && import.meta.env?.VITE_DEFAULT_MODEL;
-export const DEFAULT_MODEL_ID = (envDefault && AVAILABLE_MODELS.some((m) => m.id === envDefault)) ? envDefault : 'gemini-2.5-flash';
+export const DEFAULT_MODEL_ID = (envDefault && AVAILABLE_MODELS.some((m) => m.id === envDefault)) ? envDefault : 'gpt-5.4-nano';
 
 export const getModel = (id) => AVAILABLE_MODELS.find((m) => m.id === id);
 export const getProvider = (id) => getModel(id)?.provider;

--- a/tools/model-test.js
+++ b/tools/model-test.js
@@ -22,8 +22,8 @@ const SAMPLE_TEXT = `AIは近年急速に発展しており、多くの分野で
 
 // モデル一覧（models.jsと同期）
 const MODELS = [
-  { id: 'gpt-4.1-nano', provider: 'openai' },
-  { id: 'gpt-4.1-mini', provider: 'openai' },
+  { id: 'gpt-5.4-nano', provider: 'openai' },
+  { id: 'gpt-5.4-mini', provider: 'openai' },
   { id: 'claude-haiku-4-5-20251001', provider: 'anthropic' },
   { id: 'claude-sonnet-4-5-20250929', provider: 'anthropic' },
   { id: 'gemini-2.5-flash', provider: 'gemini' },


### PR DESCRIPTION
## Summary
This PR upgrades the OpenAI model lineup from GPT-4.1 to GPT-5.4 and adds validation to prevent stale model IDs from being used after model updates.

## Key Changes

- **Model Upgrade**: Replaced `gpt-4.1-nano` and `gpt-4.1-mini` with `gpt-5.4-nano` and `gpt-5.4-mini`
  - Updated pricing: nano ($0.05/$0.20 per 1K tokens), mini ($0.30/$1.20 per 1K tokens)
  - Improved quality ratings: nano (3→3), mini (3→4)
  - Updated descriptions: nano remains "最速・最安", mini changed to "高品質"

- **Model Validation**: Added localStorage validation in TextEditor component
  - Checks if saved model ID exists in `AVAILABLE_MODELS`
  - Automatically resets to `DEFAULT_MODEL_ID` if saved model is no longer available
  - Prevents errors when users have old model IDs cached from previous versions

- **Token Limit Adjustment**: Implemented dynamic max token limits for OpenAI API calls
  - GPT-5.4 nano: 4000 tokens (cost optimization)
  - Other models: 16000 tokens

- **Documentation Updates**: Updated `.env.example` and comments to reflect new default model

## Implementation Details

The model validation logic gracefully handles the case where users have cached an outdated model ID in localStorage. When the app loads, it checks if the saved model is still available; if not, it resets to the default and updates localStorage accordingly. This ensures a smooth experience during model transitions without requiring manual cache clearing.

https://claude.ai/code/session_015bdYD3nX1NFyno7ZEyY1HM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * モデル提供者別でフィルタリングする機能を追加しました。

* **改善**
  * OpenAIモデルを最新版に更新しました（gpt-5.4-nano、gpt-5.4-mini）。
  * モデルの価格情報と性能スペックを更新しました。
  * 保存されたモデル設定の検証を強化し、無効な設定は自動的にリセットされるようになりました。
  * トークン上限の設定をモデル種別に応じて最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->