### PR TITLE
Anthropicプロバイダーを削除

### DIFF
--- a/src/config/models.js
+++ b/src/config/models.js
@@ -2,7 +2,6 @@
 // speed: 1-5 (5が最速), quality: 1-5 (5が最高品質)
 export const PROVIDERS = {
   openai: { name: 'OpenAI', envKey: 'OPENAI_API_KEY' },
-  anthropic: { name: 'Anthropic', envKey: 'ANTHROPIC_API_KEY' },
   gemini: { name: 'Google Gemini', envKey: 'GEMINI_API_KEY' },
 };
 
@@ -11,10 +10,6 @@ export const AVAILABLE_MODELS = [
   // OpenAI
   { id: 'gpt-5.4-nano', provider: 'openai', name: 'GPT-5.4 Nano', description: '最速・最安', inputPrice: 0.05, outputPrice: 0.20, speed: 5, quality: 3, secsPerKChar: 3 },
   { id: 'gpt-5.4-mini', provider: 'openai', name: 'GPT-5.4 Mini', description: '高品質', inputPrice: 0.30, outputPrice: 1.20, speed: 4, quality: 4, secsPerKChar: 5 },
-
-  // Anthropic
-  { id: 'claude-haiku-4-5-20251001', provider: 'anthropic', name: 'Claude 4.5 Haiku', description: '最速・最安', inputPrice: 0.80, outputPrice: 4.00, speed: 5, quality: 3, secsPerKChar: 4 },
-  { id: 'claude-sonnet-4-5-20250929', provider: 'anthropic', name: 'Claude 4.5 Sonnet', description: 'バランス型', inputPrice: 3.00, outputPrice: 15.00, speed: 3, quality: 4, secsPerKChar: 10 },
 
   // Google Gemini
   { id: 'gemini-2.5-flash', provider: 'gemini', name: 'Gemini 2.5 Flash', description: '最速・最安', inputPrice: 0.10, outputPrice: 0.40, speed: 5, quality: 3, secsPerKChar: 4 },
@@ -27,8 +22,8 @@ export const AVAILABLE_MODELS = [
  * @returns {string} モデルID
  */
 export function autoSelectModel(charCount, isAvailable) {
-  // プロバイダー優先順: openai > gemini > anthropic
-  const providerOrder = ['openai', 'gemini', 'anthropic'];
+  // プロバイダー優先順: openai > gemini
+  const providerOrder = ['openai', 'gemini'];
   const available = providerOrder.find((p) => isAvailable(p));
   if (!available) return DEFAULT_MODEL_ID;
 


### PR DESCRIPTION
## 概要
Anthropic API は使用予定がないため、フロントエンドの選択肢から削除します。

## 変更
- `src/config/models.js`: PROVIDERS / AVAILABLE_MODELS / autoSelectModel の優先順から anthropic を除去
- 設定画面のキー入力欄・接続テスト、モデル選択ドロップダウンは PROVIDERS から生成されるため自動的に非表示になります
- localStorage に旧 Claude モデル ID が残っている場合は既存のリセット処理でデフォルトに戻ります

## 備考
- サーバー側（api/_shared.js）の anthropic 分岐は残していますが、キー未設定のため到達しません（必要なら別途削除可）